### PR TITLE
docs: expand monorepo plan with test organization and config migration

### DIFF
--- a/features/monorepo-structure.md
+++ b/features/monorepo-structure.md
@@ -335,16 +335,334 @@ cd src/pmd && uv build
 
 ---
 
+## Test Organization
+
+### Current Test Structure
+
+```
+tests/
+├── conftest.py           # Shared fixtures
+├── fixtures/             # Test data files
+├── fakes/                # Mock implementations
+├── unit/
+│   ├── app/
+│   ├── core/
+│   ├── llm/
+│   ├── metadata/
+│   ├── search/
+│   ├── services/
+│   ├── sources/
+│   └── store/
+└── integration/
+    ├── conftest.py
+    ├── test_collection_indexing.py
+    ├── test_corpus_hybrid_search.py
+    └── ...
+```
+
+### Options for Test Organization
+
+#### Option A: Keep Tests Centralized at Root (Recommended)
+
+**Structure:**
+```
+mdindex/
+├── tests/                    # All tests remain here
+│   ├── conftest.py
+│   ├── fixtures/
+│   ├── fakes/
+│   ├── unit/
+│   │   └── pmd/              # Rename from mirroring src/pmd structure
+│   └── integration/
+├── src/
+│   └── pmd/
+└── app/
+```
+
+**Pros:**
+- No migration required - tests stay where they are
+- Shared fixtures (`conftest.py`, `fixtures/`, `fakes/`) work naturally
+- Easy to run all tests at once: `uv run pytest`
+- Integration tests that span libraries have a natural home
+
+**Cons:**
+- Tests don't travel with library when published (usually fine - tests aren't typically distributed)
+- As more libraries are added, test organization needs clear conventions
+
+**Configuration (root pyproject.toml):**
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["src/pmd", "app"]
+branch = true
+```
+
+#### Option B: Co-located Tests (Tests Inside Each Library)
+
+**Structure:**
+```
+mdindex/
+├── tests/                    # Root-level integration/E2E tests only
+│   └── integration/
+├── src/
+│   └── pmd/
+│       ├── pyproject.toml
+│       ├── tests/            # pmd's unit tests
+│       │   ├── conftest.py
+│       │   ├── unit/
+│       │   └── fixtures/
+│       └── ...
+└── app/
+    └── tests/                # app's tests
+```
+
+**Pros:**
+- Clear ownership - each library's tests are with the library
+- Tests travel with library if published with `include-package-data`
+- Easy to run tests for just one library: `uv run pytest src/pmd/tests`
+
+**Cons:**
+- Shared fixtures need duplication or extraction to a `tests-common` package
+- More complex pytest configuration
+- Current test structure would need significant reorganization
+
+**Configuration (src/pmd/pyproject.toml):**
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+```
+
+#### Option C: Hybrid Approach
+
+**Structure:**
+```
+mdindex/
+├── tests/
+│   ├── conftest.py           # Shared across all tests
+│   ├── fixtures/             # Shared fixtures
+│   ├── fakes/                # Shared mocks
+│   ├── integration/          # Cross-library integration tests
+│   └── e2e/                  # End-to-end tests
+├── src/
+│   └── pmd/
+│       └── tests/            # pmd unit tests only
+│           └── unit/
+└── app/
+    └── tests/
+```
+
+**Recommendation: Option A (Centralized)** for this project because:
+1. Current test structure already works well
+2. Shared fixtures are extensively used
+3. Integration tests are important and span pmd modules
+4. No immediate need to distribute tests with published packages
+
+---
+
+## Configuration Migration Reference
+
+### What Moves to `src/pmd/pyproject.toml`
+
+| Section | Move? | Reasoning |
+|---------|-------|-----------|
+| `[project]` name, version, description | **Yes** | Library identity |
+| `[project]` readme, authors, license | **Yes** | Library metadata |
+| `[project]` requires-python | **Yes** | Library requirement |
+| `dependencies` | **Yes** | pmd's runtime dependencies |
+| `[project.optional-dependencies].loaders` | **Yes** | pmd-specific optional deps |
+| `[project.scripts]` pmd CLI | **Yes** | pmd's entry point |
+| `[tool.hatch.build.targets.wheel]` | **Yes** | But simplified: `packages = ["."]` |
+
+### What Stays at Root `pyproject.toml`
+
+| Section | Reasoning |
+|---------|-----------|
+| `[tool.uv.workspace]` | Workspace definition |
+| `[tool.uv.sources]` | Workspace member references |
+| `[project.optional-dependencies].dev` | Workspace-wide dev tools |
+| `[dependency-groups].dev` | Workspace-wide dev dependencies |
+| `[tool.pytest.ini_options]` | Tests run from root |
+| `[tool.coverage.*]` | Coverage spans all packages |
+| `[tool.mypy]` | Workspace-wide type checking settings |
+| `[tool.ruff]` | Workspace-wide linting settings |
+
+### Special Considerations
+
+**README handling:**
+- pmd's `pyproject.toml` can reference the root README: `readme = "../../README.md"`
+- Or create a pmd-specific README at `src/pmd/README.md`
+
+**Version management:**
+- Each library has its own version in its `pyproject.toml`
+- Root package version is separate (if it even needs one)
+
+**Entry points / Scripts:**
+- `[project.scripts]` moves to the library that provides the CLI
+- Multiple libraries can each define their own scripts
+
+---
+
+## Detailed File Changes
+
+### `src/pmd/pyproject.toml` (NEW)
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pmd"
+version = "1.0.0"
+description = "Python Markdown Search - Hybrid search engine for markdown documents"
+readme = "../../README.md"
+requires-python = ">=3.11"
+authors = [
+    {name = "Mike", email = "mike@example.com"},
+]
+license = {text = "MIT"}
+
+dependencies = [
+    "sqlite-vec>=0.1.0",
+    "httpx>=0.27.0",
+    "rich>=13.0.0",
+    "click>=8.1.0",
+    "pydantic>=2.0.0",
+    "mlx-lm>=0.29.1",
+    "mlx-embeddings>=0.0.5",
+    "loguru>=0.7.3",
+    "opentelemetry-sdk>=1.39.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.39.1",
+    "arize-phoenix[all]>=12.27.0",
+    "arize-phoenix-otel>=0.14.0",
+    "pyyaml>=6.0.3",
+    "sqlalchemy>=2.0.0",
+    "alembic>=1.13.0",
+    "aiosqlite>=0.20.0",
+    "fsspec>=2024.0.0",
+    "litellm>=1.50.0",
+    "dspy>=2.5.0",
+]
+
+[project.optional-dependencies]
+loaders = [
+    "llama-index-core>=0.11.0",
+    "llama-index-readers-web>=0.2.0",
+    "llama-index-readers-file>=0.2.0",
+]
+
+[project.scripts]
+pmd = "pmd.cli.main:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+```
+
+### Root `pyproject.toml` (MODIFIED)
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mdindex"
+version = "1.0.0"
+description = "mdindex monorepo workspace"
+requires-python = ">=3.11"
+authors = [
+    {name = "Mike", email = "mike@example.com"},
+]
+license = {text = "MIT"}
+
+# Workspace members as dependencies (auto-editable)
+dependencies = [
+    "pmd",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=4.0.0",
+    "mypy>=1.8.0",
+    "ruff>=0.2.0",
+]
+
+# ============================================================
+# UV WORKSPACE
+# ============================================================
+[tool.uv.workspace]
+members = ["src/*"]
+
+[tool.uv.sources]
+pmd = { workspace = true }
+
+# ============================================================
+# HATCH BUILD (for app/ if needed)
+# ============================================================
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+# ============================================================
+# TESTING (centralized)
+# ============================================================
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "--cov=src/pmd --cov-report=term-missing --cov-report=html"
+
+[tool.coverage.run]
+source = ["src/pmd", "app"]
+branch = true
+omit = ["*/tests/*", "*/__pycache__/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+show_missing = true
+
+# ============================================================
+# LINTING & TYPE CHECKING (workspace-wide)
+# ============================================================
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_configs = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+# ============================================================
+# DEV DEPENDENCIES
+# ============================================================
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=6.0.0",
+    "respx>=0.22.0",
+    "tach>=0.33.0",
+]
+```
+
+---
+
 ## Considerations
 
 ### Publishing
 - Each library in `src/` can be published independently to PyPI
 - The root package (`mdindex`) is typically NOT published
 - Use `uv build` within each library directory to create distributions
-
-### Testing
-- Tests can remain centralized in `tests/` or be distributed per-library
-- Coverage configuration may need adjustment for multiple packages
 
 ### Versioning
 - Each library manages its own version in its `pyproject.toml`


### PR DESCRIPTION
- Add three test organization options with recommendation
- Add detailed table of what config moves vs stays at root
- Include complete example pyproject.toml files for both locations
- Document special considerations for README, versions, and entry points

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the monorepo plan with concrete testing and configuration guidance.
> 
> - Adds a **Test Organization** section with three options (centralized, co-located, hybrid) and recommends keeping tests centralized under `tests/` with shared fixtures
> - Introduces a **Configuration Migration Reference** detailing what moves to `src/pmd/pyproject.toml` vs. what stays in the root
> - Provides complete example `pyproject.toml` files for `src/pmd/` (new package config with deps, CLI, optional loaders) and the root (uv workspace members/sources, pytest/coverage config, mypy/ruff, hatch build for `app/`)
> - Documents special considerations for README handling, versioning per package, and entry points/scripts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068ae69dd3df24bd362cff61f8215b495ca9843a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->